### PR TITLE
The production server now has a permanent FQDN.

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,1 +1,1 @@
-server "lrc-perrier.local", user: "lrcerebro", roles: %w[app db web]
+server "lrcerebro.mll.gvsu.edu", user: "lrcerebro", roles: %w[app db web]


### PR DESCRIPTION
We were using mDNS before to get access to the server but now that it
has a proper and permanent domain name we should be using that.